### PR TITLE
Update deprecated NLLLoss2d to NLLLoss

### DIFF
--- a/criterion.py
+++ b/criterion.py
@@ -5,7 +5,7 @@ class CrossEntropyLoss2d(nn.Module):
 
     def __init__(self, weight=None):
         super().__init__()
-        self.loss = nn.NLLLoss2d(weight)
+        self.loss = nn.NLLLoss(weight)
 
     def forward(self, outputs, mask):
         return self.loss(F.log_softmax(outputs,dim=1), mask)


### PR DESCRIPTION
NLLLoss2d is NLLLoss in Pytorch 1.4